### PR TITLE
Footer overlap issue resolved

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -184,7 +184,7 @@ transform: scale(1.1);
   text-transform: uppercase;
   font-size: 20px;
   font-weight: 400;
-  line-height: 24px;
+  line-height: 20px;
   margin: 3px 0;
 }
 
@@ -219,6 +219,10 @@ transform: scale(1.1);
   bottom: 20px; 
   left: 0px; 
   text-align: center; 
+}
+
+.footer-text{
+  margin-top:1.8%;
 }
 
 .footer-text a{


### PR DESCRIPTION
Issue no: #1
Footer doesn't overlap anymore both on mobile and desktop view. The screen shot below can be taken as a reference.

![image](https://user-images.githubusercontent.com/71656941/135672633-86de3508-5645-48ae-8f9e-ef8536d1e65b.png)
